### PR TITLE
Update jaeger-go example to use latest tracer release

### DIFF
--- a/jaeger-go/Gopkg.lock
+++ b/jaeger-go/Gopkg.lock
@@ -3,27 +3,34 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:4c4c33075b704791d6a7f09dfb55c66769e8a1dc6adf87026292d274fe8ad113"
   name = "github.com/codahale/hdrhistogram"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
+  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
   ]
+  pruneopts = "UT"
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:ac6f26e917fd2fb3194a7ebe2baf6fb32de2f2fbfed130c18aac0e758a6e1d22"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -42,26 +49,34 @@
     "thrift-gen/sampling",
     "thrift-gen/zipkincore",
     "transport",
-    "utils"
+    "utils",
   ]
-  revision = "b043381d944715b469fd6b37addfd30145ca1758"
-  version = "v2.14.0"
+  pruneopts = "UT"
+  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
+  version = "v2.15.0"
 
 [[projects]]
+  digest = "1:0f09db8429e19d57c8346ad76fbbc679341fa86073d3b8fb5ac919f0357d8f4c"
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
+  pruneopts = "UT"
   revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
   version = "v1.5.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = "UT"
   revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2bf16b03d17e13ed292ce0a9745bdcd28f5d20ddf0550f072874b89fc536d94a"
+  input-imports = [
+    "github.com/opentracing/opentracing-go",
+    "github.com/uber/jaeger-client-go/config",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/jaeger-go/Gopkg.toml
+++ b/jaeger-go/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
-  version = "2.14.0"
+  version = "2.15.0"
 
 [prune]
   go-tests = true

--- a/jaeger-go/README.md
+++ b/jaeger-go/README.md
@@ -5,12 +5,24 @@ See [./main.go](./main.go) for the example code.
 
 ## Building
 
-To run this example locally, from this directory do the following:
+To build this example locally, from this directory do the following:
 
 ```
 $ ln -s $(dirname $(pwd)) $GOPATH/src/github.com/signalfx/tracing-examples
 $ cd $GOPATH/src/github.com/signalfx/tracing-examples/jaeger-go
 $ go build .
+```
+
+Now, to run it you need to configure the Jaeger tracer.  The simplest way to do
+this is via environment variables:
+
+```sh
+$ # Change this to whatever your app is called
+$ export JAEGER_SERVICE_NAME=my-app
+$ # This will be different if using the Smart Agent/Gateway deployment model
+$ export JAEGER_ENDPOINT=https://ingest.signalfx.com/v1/trace
+$ export JAEGER_PASSWORD=<MY_ORG_TOKEN>
+
 $ ./jaeger-go
 ```
 

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/CHANGELOG.md
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changes by Version
 ==================
 
+2.15.0 (2018-10-10)
+-------------------
+
+- Fix FollowsFrom spans ignoring baggage/debug header from dummy parent context (#313) <Zvi Cahana>
+- Make maximum annotation length configurable in tracer options (#318) <Eric Chang>
+- Support more environment variables in configuration (#323) <Daneyon Hansen>
+- Print error on Sampler Query failure (#328) <Goutham Veeramachaneni>
+- Add an HTTPOption to support custom http.RoundTripper (#333) <Michael Puncel>
+- Return an error when an HTTP error code is seen in zipkin HTTP transport <Michael Puncel>
+
+
 2.14.0 (2018-04-30)
 -------------------
 

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/README.md
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/README.md
@@ -51,17 +51,26 @@ Property| Description
 JAEGER_SERVICE_NAME | The service name
 JAEGER_AGENT_HOST | The hostname for communicating with agent via UDP
 JAEGER_AGENT_PORT | The port for communicating with agent via UDP
+JAEGER_ENDPOINT | The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces
+JAEGER_USER | Username to send as part of "Basic" authentication to the collector endpoint
+JAEGER_PASSWORD | Password to send as part of "Basic" authentication to the collector endpoint
 JAEGER_REPORTER_LOG_SPANS | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
-JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
+JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval, with units, e.g. "500ms" or "2s" ([valid units][timeunits])
 JAEGER_SAMPLER_TYPE | The sampler type
 JAEGER_SAMPLER_PARAM | The sampler parameter (number)
-JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler
+JAEGER_SAMPLER_MANAGER_HOST_PORT | The HTTP endpoint when using the remote sampler, i.e. http://jaeger-agent:5778/sampling
 JAEGER_SAMPLER_MAX_OPERATIONS | The maximum number of operations that the sampler will keep track of
-JAEGER_SAMPLER_REFRESH_INTERVAL | How often the remotely controlled sampler will poll jaeger-agent for the appropriate sampling strategy
+JAEGER_SAMPLER_REFRESH_INTERVAL | How often the remotely controlled sampler will poll jaeger-agent for the appropriate sampling strategy, with units, e.g. "1m" or "30s" ([valid units][timeunits])
 JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 JAEGER_DISABLED | Whether the tracer is disabled or not. If true, the default `opentracing.NoopTracer` is used.
 JAEGER_RPC_METRICS | Whether to store RPC metrics
+
+By default, the client sends traces via UDP to the agent at `localhost:6831`. Use `JAEGER_AGENT_HOST` and
+`JAEGER_AGENT_PORT` to send UDP traces to a different `host:port`. If `JAEGER_ENDPOINT` is set, the client sends traces
+to the endpoint via `HTTP`, making the `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT` unused. If `JAEGER_ENDPOINT` is
+secured, HTTP basic authentication can be performed by setting the `JAEGER_USER` and `JAEGER_PASSWORD` environment
+variables.
 
 ### Closing the tracer via `io.Closer`
 
@@ -258,3 +267,4 @@ However it is not the default propagation format, see [here](zipkin/README.md#Ne
 [ot-img]: https://img.shields.io/badge/OpenTracing--1.0-enabled-blue.svg
 [ot-url]: http://opentracing.io
 [baggage]: https://github.com/opentracing/specification/blob/master/specification.md#set-a-baggage-item
+[timeunits]: https://golang.org/pkg/time/#ParseDuration

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/config.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/jaeger-client-go/internal/baggage/remote"
 	throttler "github.com/uber/jaeger-client-go/internal/throttler/remote"
 	"github.com/uber/jaeger-client-go/rpcmetrics"
+	"github.com/uber/jaeger-client-go/transport"
 )
 
 const defaultSamplingProbability = 0.001
@@ -108,6 +109,18 @@ type ReporterConfig struct {
 	// LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
 	// Can be set by exporting an environment variable named JAEGER_AGENT_HOST / JAEGER_AGENT_PORT
 	LocalAgentHostPort string `yaml:"localAgentHostPort"`
+
+	// CollectorEndpoint instructs reporter to send spans to jaeger-collector at this URL
+	// Can be set by exporting an environment variable named JAEGER_ENDPOINT
+	CollectorEndpoint string `yaml:"collectorEndpoint"`
+
+	// User instructs reporter to include a user for basic http authentication when sending spans to jaeger-collector.
+	// Can be set by exporting an environment variable named JAEGER_USER
+	User string `yaml:"user"`
+
+	// Password instructs reporter to include a password for basic http authentication when sending spans to
+	// jaeger-collector. Can be set by exporting an environment variable named JAEGER_PASSWORD
+	Password string `yaml:"password"`
 }
 
 // BaggageRestrictionsConfig configures the baggage restrictions manager which can be used to whitelist
@@ -218,6 +231,7 @@ func (c Configuration) NewTracer(options ...Option) (opentracing.Tracer, io.Clos
 		jaeger.TracerOptions.CustomHeaderKeys(c.Headers),
 		jaeger.TracerOptions.Gen128Bit(opts.gen128Bit),
 		jaeger.TracerOptions.ZipkinSharedRPCSpan(opts.zipkinSharedRPCSpan),
+		jaeger.TracerOptions.MaxTagValueLength(opts.maxTagValueLength),
 	}
 
 	for _, tag := range opts.tags {
@@ -344,7 +358,7 @@ func (sc *SamplerConfig) NewSampler(
 	return nil, fmt.Errorf("Unknown sampler type %v", sc.Type)
 }
 
-// NewReporter instantiates a new reporter that submits spans to tcollector
+// NewReporter instantiates a new reporter that submits spans to the collector
 func (rc *ReporterConfig) NewReporter(
 	serviceName string,
 	metrics *jaeger.Metrics,
@@ -368,5 +382,13 @@ func (rc *ReporterConfig) NewReporter(
 }
 
 func (rc *ReporterConfig) newTransport() (jaeger.Transport, error) {
-	return jaeger.NewUDPTransport(rc.LocalAgentHostPort, 0)
+	switch {
+	case rc.CollectorEndpoint != "" && rc.User != "" && rc.Password != "":
+		return transport.NewHTTPTransport(rc.CollectorEndpoint, transport.HTTPBatchSize(1),
+			transport.HTTPBasicAuth(rc.User, rc.Password)), nil
+	case rc.CollectorEndpoint != "":
+		return transport.NewHTTPTransport(rc.CollectorEndpoint, transport.HTTPBatchSize(1)), nil
+	default:
+		return jaeger.NewUDPTransport(rc.LocalAgentHostPort, 0)
+	}
 }

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/config_env.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/config_env.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -41,6 +42,9 @@ const (
 	envReporterMaxQueueSize   = "JAEGER_REPORTER_MAX_QUEUE_SIZE"
 	envReporterFlushInterval  = "JAEGER_REPORTER_FLUSH_INTERVAL"
 	envReporterLogSpans       = "JAEGER_REPORTER_LOG_SPANS"
+	envEndpoint               = "JAEGER_ENDPOINT"
+	envUser                   = "JAEGER_USER"
+	envPassword               = "JAEGER_PASSWORD"
 	envAgentHost              = "JAEGER_AGENT_HOST"
 	envAgentPort              = "JAEGER_AGENT_PORT"
 )
@@ -156,12 +160,19 @@ func reporterConfigFromEnv() (*ReporterConfig, error) {
 	}
 
 	host := jaeger.DefaultUDPSpanServerHost
+	ep := os.Getenv(envEndpoint)
 	if e := os.Getenv(envAgentHost); e != "" {
+		if ep != "" {
+			return nil, errors.Errorf("cannot set env vars %s and %s together", envAgentHost, envEndpoint)
+		}
 		host = e
 	}
 
 	port := jaeger.DefaultUDPSpanServerPort
 	if e := os.Getenv(envAgentPort); e != "" {
+		if ep != "" {
+			return nil, errors.Errorf("cannot set env vars %s and %s together", envAgentPort, envEndpoint)
+		}
 		if value, err := strconv.ParseInt(e, 10, 0); err == nil {
 			port = int(value)
 		} else {
@@ -172,6 +183,22 @@ func reporterConfigFromEnv() (*ReporterConfig, error) {
 	// the side effect of this is that we are building the default value, even if none of the env vars
 	// were not explicitly passed
 	rc.LocalAgentHostPort = fmt.Sprintf("%s:%d", host, port)
+
+	if ep != "" {
+		u, err := url.ParseRequestURI(ep)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot parse env var %s=%s", envEndpoint, ep)
+		}
+		rc.CollectorEndpoint = fmt.Sprintf("%s", u)
+	}
+
+	user := os.Getenv(envUser)
+	pswd := os.Getenv(envPassword)
+	if user != "" && pswd == "" || user == "" && pswd != "" {
+		return nil, errors.Errorf("you must set %s and %s env vars together", envUser, envPassword)
+	}
+	rc.User = user
+	rc.Password = pswd
 
 	return rc, nil
 }

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/options.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/config/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	observers           []jaeger.Observer
 	gen128Bit           bool
 	zipkinSharedRPCSpan bool
+	maxTagValueLength   int
 	tags                []opentracing.Tag
 	injectors           map[interface{}]jaeger.Injector
 	extractors          map[interface{}]jaeger.Extractor
@@ -98,6 +99,13 @@ func Gen128Bit(gen128Bit bool) Option {
 func ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) Option {
 	return func(c *Options) {
 		c.zipkinSharedRPCSpan = zipkinSharedRPCSpan
+	}
+}
+
+// MaxTagValueLength can be provided to override the default max tag value length.
+func MaxTagValueLength(maxTagValueLength int) Option {
+	return func(c *Options) {
+		c.maxTagValueLength = maxTagValueLength
 	}
 }
 

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/constants.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/constants.go
@@ -16,7 +16,7 @@ package jaeger
 
 const (
 	// JaegerClientVersion is the version of the client library reported as Span tag.
-	JaegerClientVersion = "Go-2.14.0"
+	JaegerClientVersion = "Go-2.15.0"
 
 	// JaegerClientVersionTagKey is the name of the tag used to report client version.
 	JaegerClientVersionTagKey = "jaeger.version"
@@ -82,4 +82,7 @@ const (
 
 	// DefaultUDPSpanServerPort is the default port to send the spans to, via UDP
 	DefaultUDPSpanServerPort = 6831
+
+	// DefaultMaxTagValueLength is the default max length of byte array or string allowed in the tag value.
+	DefaultMaxTagValueLength = 256
 )

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/jaeger_thrift_span.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/jaeger_thrift_span.go
@@ -38,7 +38,7 @@ func BuildJaegerThrift(span *Span) *j.Span {
 		Flags:         int32(span.context.flags),
 		StartTime:     startTime,
 		Duration:      duration,
-		Tags:          buildTags(span.tags),
+		Tags:          buildTags(span.tags, span.tracer.options.maxTagValueLength),
 		Logs:          buildLogs(span.logs),
 		References:    buildReferences(span.references),
 	}
@@ -55,7 +55,7 @@ func BuildJaegerProcessThrift(span *Span) *j.Process {
 func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	process := &j.Process{
 		ServiceName: tracer.serviceName,
-		Tags:        buildTags(tracer.tags),
+		Tags:        buildTags(tracer.tags, tracer.options.maxTagValueLength),
 	}
 	if tracer.process.UUID != "" {
 		process.Tags = append(process.Tags, &j.Tag{Key: TracerUUIDTagKey, VStr: &tracer.process.UUID, VType: j.TagType_STRING})
@@ -63,10 +63,10 @@ func buildJaegerProcessThrift(tracer *Tracer) *j.Process {
 	return process
 }
 
-func buildTags(tags []Tag) []*j.Tag {
+func buildTags(tags []Tag, maxTagValueLength int) []*j.Tag {
 	jTags := make([]*j.Tag, 0, len(tags))
 	for _, tag := range tags {
-		jTag := buildTag(&tag)
+		jTag := buildTag(&tag, maxTagValueLength)
 		jTags = append(jTags, jTag)
 	}
 	return jTags
@@ -84,16 +84,16 @@ func buildLogs(logs []opentracing.LogRecord) []*j.Log {
 	return jLogs
 }
 
-func buildTag(tag *Tag) *j.Tag {
+func buildTag(tag *Tag, maxTagValueLength int) *j.Tag {
 	jTag := &j.Tag{Key: tag.key}
 	switch value := tag.value.(type) {
 	case string:
-		vStr := truncateString(value)
+		vStr := truncateString(value, maxTagValueLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	case []byte:
-		if len(value) > maxAnnotationLength {
-			value = value[:maxAnnotationLength]
+		if len(value) > maxTagValueLength {
+			value = value[:maxTagValueLength]
 		}
 		jTag.VBinary = value
 		jTag.VType = j.TagType_BINARY
@@ -150,7 +150,7 @@ func buildTag(tag *Tag) *j.Tag {
 		jTag.VBool = &vBool
 		jTag.VType = j.TagType_BOOL
 	default:
-		vStr := truncateString(stringify(value))
+		vStr := truncateString(stringify(value), maxTagValueLength)
 		jTag.VStr = &vStr
 		jTag.VType = j.TagType_STRING
 	}

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/sampler.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/sampler.go
@@ -511,6 +511,7 @@ func (s *RemotelyControlledSampler) updateSampler() {
 	res, err := s.manager.GetSamplingStrategy(s.serviceName)
 	if err != nil {
 		s.metrics.SamplerQueryFailure.Inc(1)
+		s.logger.Infof("Unable to query sampling strategy: %v", err)
 		return
 	}
 	s.Lock()

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/tracer.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/tracer.go
@@ -50,6 +50,7 @@ type Tracer struct {
 		gen128Bit            bool // whether to generate 128bit trace IDs
 		zipkinSharedRPCSpan  bool
 		highTraceIDGenerator func() uint64 // custom high trace ID generator
+		maxTagValueLength    int
 		// more options to come
 	}
 	// pool for Span objects
@@ -152,6 +153,9 @@ func NewTracer(
 		t.logger.Error("Overriding high trace ID generator but not generating " +
 			"128 bit trace IDs, consider enabling the \"Gen128Bit\" option")
 	}
+	if t.options.maxTagValueLength == 0 {
+		t.options.maxTagValueLength = DefaultMaxTagValueLength
+	}
 	t.process = Process{
 		Service: serviceName,
 		UUID:    strconv.FormatUint(t.randomNumber(), 16),
@@ -194,6 +198,12 @@ func (t *Tracer) startSpanWithOptions(
 		options.StartTime = t.timeNow()
 	}
 
+	// Predicate whether the given span context is a valid reference
+	// which may be used as parent / debug ID / baggage items source
+	isValidReference := func(ctx SpanContext) bool {
+		return ctx.IsValid() || ctx.isDebugIDContainerOnly() || len(ctx.baggage) != 0
+	}
+
 	var references []Reference
 	var parent SpanContext
 	var hasParent bool // need this because `parent` is a value, not reference
@@ -205,7 +215,7 @@ func (t *Tracer) startSpanWithOptions(
 				reflect.ValueOf(ref.ReferencedContext)))
 			continue
 		}
-		if !(ctx.IsValid() || ctx.isDebugIDContainerOnly() || len(ctx.baggage) != 0) {
+		if !isValidReference(ctx) {
 			continue
 		}
 		references = append(references, Reference{Type: ref.Type, Context: ctx})
@@ -214,7 +224,7 @@ func (t *Tracer) startSpanWithOptions(
 			hasParent = ref.Type == opentracing.ChildOfRef
 		}
 	}
-	if !hasParent && parent.IsValid() {
+	if !hasParent && isValidReference(parent) {
 		// If ChildOfRef wasn't found but a FollowFromRef exists, use the context from
 		// the FollowFromRef as the parent
 		hasParent = true

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/tracer_options.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/tracer_options.go
@@ -128,6 +128,12 @@ func (tracerOptions) HighTraceIDGenerator(highTraceIDGenerator func() uint64) Tr
 	}
 }
 
+func (tracerOptions) MaxTagValueLength(maxTagValueLength int) TracerOption {
+	return func(tracer *Tracer) {
+		tracer.options.maxTagValueLength = maxTagValueLength
+	}
+}
+
 func (tracerOptions) ZipkinSharedRPCSpan(zipkinSharedRPCSpan bool) TracerOption {
 	return func(tracer *Tracer) {
 		tracer.options.zipkinSharedRPCSpan = zipkinSharedRPCSpan

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/transport/http.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/transport/http.go
@@ -68,6 +68,14 @@ func HTTPBasicAuth(username string, password string) HTTPOption {
 	}
 }
 
+// HTTPRoundTripper configures the underlying Transport on the *http.Client
+// that is used
+func HTTPRoundTripper(transport http.RoundTripper) HTTPOption {
+	return func(c *HTTPTransport) {
+		c.client.Transport = transport
+	}
+}
+
 // NewHTTPTransport returns a new HTTP-backend transport. url should be an http
 // url of the collector to handle POST request, typically something like:
 //     http://hostname:14268/api/traces?format=jaeger.thrift

--- a/jaeger-go/vendor/github.com/uber/jaeger-client-go/zipkin_thrift_span.go
+++ b/jaeger-go/vendor/github.com/uber/jaeger-client-go/zipkin_thrift_span.go
@@ -27,9 +27,6 @@ import (
 )
 
 const (
-	// maxAnnotationLength is the max length of byte array or string allowed in the annotations
-	maxAnnotationLength = 256
-
 	// Zipkin UI does not work well with non-string tag values
 	allowPackedNumbers = false
 )
@@ -98,7 +95,7 @@ func buildAnnotations(span *zipkinSpan, endpoint *z.Endpoint) []*z.Annotation {
 			Timestamp: utils.TimeToMicrosecondsSinceEpochInt64(log.Timestamp),
 			Host:      endpoint}
 		if content, err := spanlog.MaterializeWithJSON(log.Fields); err == nil {
-			anno.Value = truncateString(string(content))
+			anno.Value = truncateString(string(content), span.tracer.options.maxTagValueLength)
 		} else {
 			anno.Value = err.Error()
 		}
@@ -148,21 +145,21 @@ func buildBinaryAnnotations(span *zipkinSpan, endpoint *z.Endpoint) []*z.BinaryA
 		if _, ok := specialTagHandlers[tag.key]; ok {
 			continue
 		}
-		if anno := buildBinaryAnnotation(tag.key, tag.value, nil); anno != nil {
+		if anno := buildBinaryAnnotation(tag.key, tag.value, span.tracer.options.maxTagValueLength, nil); anno != nil {
 			annotations = append(annotations, anno)
 		}
 	}
 	return annotations
 }
 
-func buildBinaryAnnotation(key string, val interface{}, endpoint *z.Endpoint) *z.BinaryAnnotation {
+func buildBinaryAnnotation(key string, val interface{}, maxTagValueLength int, endpoint *z.Endpoint) *z.BinaryAnnotation {
 	bann := &z.BinaryAnnotation{Key: key, Host: endpoint}
 	if value, ok := val.(string); ok {
-		bann.Value = []byte(truncateString(value))
+		bann.Value = []byte(truncateString(value, maxTagValueLength))
 		bann.AnnotationType = z.AnnotationType_STRING
 	} else if value, ok := val.([]byte); ok {
-		if len(value) > maxAnnotationLength {
-			value = value[:maxAnnotationLength]
+		if len(value) > maxTagValueLength {
+			value = value[:maxTagValueLength]
 		}
 		bann.Value = value
 		bann.AnnotationType = z.AnnotationType_BYTES
@@ -180,7 +177,7 @@ func buildBinaryAnnotation(key string, val interface{}, endpoint *z.Endpoint) *z
 		bann.AnnotationType = z.AnnotationType_BOOL
 	} else {
 		value := stringify(val)
-		bann.Value = []byte(truncateString(value))
+		bann.Value = []byte(truncateString(value, maxTagValueLength))
 		bann.AnnotationType = z.AnnotationType_STRING
 	}
 	return bann
@@ -193,12 +190,12 @@ func stringify(value interface{}) string {
 	return fmt.Sprintf("%+v", value)
 }
 
-func truncateString(value string) string {
+func truncateString(value string, maxLength int) string {
 	// we ignore the problem of utf8 runes possibly being sliced in the middle,
 	// as it is rather expensive to iterate through each tag just to find rune
 	// boundaries.
-	if len(value) > maxAnnotationLength {
-		return value[:maxAnnotationLength]
+	if len(value) > maxLength {
+		return value[:maxLength]
 	}
 	return value
 }


### PR DESCRIPTION
This also enables the use of more environment variables.