### PR TITLE
Update Jaeger-Python example for OT2.0

### DIFF
--- a/jaeger-python/README.md
+++ b/jaeger-python/README.md
@@ -11,9 +11,9 @@ To run this example locally, from this directory do the following:
 ```
 $ pip install -r requirements.txt
 $ # Run the server in the background (or from another shell)
-$ python pi_trace/pi_server.py -a MyOrgAccessToken &
+$ python pi_trace/pi_server.py -a <OptionalOrgAccessToken> &
 $ # Launch the client
-$ python pi_trace/pi_client.py -a MyOrgAccessToken
+$ python pi_trace/pi_client.py -a <OptionalOrgAccessToken>
 ```
 
 ## Resources
@@ -21,16 +21,13 @@ $ python pi_trace/pi_client.py -a MyOrgAccessToken
 - [Jaeger Bindings for Python OpenTracing
   API](https://github.com/jaegertracing/jaeger-client-python): the primary
   tracer implementation used in this example, a SignalFx fork of which provides
-  a required HTTPSender.
-- [OpenTracing Python
-  Instrumentation](https://github.com/uber-common/opentracing-python-instrumentation):
-  a helper library for useful span context storage and retrieval, as well as
-  instrumented libraries that are unused by this example.
+  a required HTTPSender and OpenTracing 2.0 API adoption.
 - [OpenTracing
   Python](https://github.com/opentracing/opentracing-python): the Jaeger Python
   tracer conforms to this interface, which is intended to be used by
   instrumented libraries and applications when possible over tracer
-  implementation-dependent functionality.
+  implementation-dependent functionality.  It also provides helpful scope management
+  utilities for automatically creating trace span relationships throughout your application.
 
 ## Other Resources
 

--- a/jaeger-python/pi_trace/leibniz.py
+++ b/jaeger-python/pi_trace/leibniz.py
@@ -1,27 +1,23 @@
-from opentracing_instrumentation import get_current_span, span_in_context
 from six.moves import range
 import opentracing
 
 
 def leibniz_approx(partials=4, partial_terms=25000000):
     """Approximate the value of Pi using Leibniz's formula."""
-    # Since opentracing.tracer returns a noop tracer by default, no configured tracing is
-    # required to use this function.
-    with opentracing.tracer.start_span('leibniz_approx') as root_span:
+    # Creates and activates a root span for automatic parentage in subsequent
+    # creations.  Since opentracing.tracer returns a noop tracer by default, no
+    # configured tracing is required to use this function.
+    with opentracing.tracer.start_active_span('leibniz_approx') as root_scope:
+        root_span = root_scope.span  # obtain the span from the active scope
         # Set function level tags for debugging purposes
         root_span.set_tag('leibniz_approx.partials', partials)
         root_span.set_tag('leibniz_approx.partial_terms', partial_terms)
         approx = 0
         start = 0
 
-        # opentracing_instrumentation.span_in_context will propagate
-        # the existing span for retrieval in threading.local(). This
-        # way, in single-threaded utilization, spans need not be referenced
-        # by function argument.
-        with span_in_context(root_span):
-            for _ in range(partials):
-                approx += calculate_partial(start, start + partial_terms)
-                start += partial_terms
+        for _ in range(partials):
+            approx += calculate_partial(start, start + partial_terms)
+            start += partial_terms
 
         return approx
 
@@ -30,9 +26,11 @@ def calculate_partial(start, end):
     """Calculate partial approximation of Pi.
     Distributable by summing partitioned approximations [start, end)
     """
-    # If get_current_span() finds no existing span in thread-local storage, this will be a root
-    # span.  If no opentracing compatible tracer has been initialized, this will be a noop span.
-    with opentracing.tracer.start_span('calculate_partial', child_of=get_current_span()) as span:
+    # start_active_span will automatically establish child reference with active span of existing trace,
+    # if one provided by scope manager.  If none determined to be active, this will create a new root span.
+    # If no opentracing-compatible tracer has been initialized, this will be a noop span.
+    with opentracing.tracer.start_active_span('calculate_partial') as scope:
+        span = scope.span
         span.set_tag('calculate_partial.start', start)
         span.set_tag('calculate_partial.end', end)
 

--- a/jaeger-python/pi_trace/pi_client.py
+++ b/jaeger-python/pi_trace/pi_client.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 from argparse import ArgumentParser
-from queue import Queue
 from time import sleep
 import logging
 
 from concurrent.futures import ThreadPoolExecutor
+from six.moves import queue as Queue
 from opentracing.ext import tags
 from jaeger_client import Config
 from requests import post
 import opentracing
 
 from propagation import context_headers
-
 
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level='DEBUG')
 
@@ -20,21 +19,24 @@ def approximate_pi(partials, partial_terms, batch_size, url):
     """An instrumented Pi approximation client that propagates its span context to
     partial sum workers via B3.
     """
-    # opentracing.tracer is a previously initialized tracer or a noop tracer if not globally initialized.
-    # Noop tracer provides noop tracer and span implementations for all high-level interfaces.
-    with opentracing.tracer.start_span('pi_approximation') as root_span:
+    # opentracing.tracer is a previously initialized tracer or a noop tracer if none exists.
+    # Noop tracer provides noop tracer, scope, and span implementations for all high-level interfaces
+    # to ensure instrumentation doesn't introduce runtime dependency.
+    with opentracing.tracer.start_active_span('pi_approximation') as root_scope:
+        root_span = root_scope.span  # obtain the span from the activated scope
         # Set function-level tags for debugging and trace context
         root_span.set_tag('pi_approximation.total_terms', partials * partial_terms)
 
-        # Nesting span context managers and using the child_of references allows
-        # parent spans to persist through their children's duration
-        with opentracing.tracer.start_span('pi_map', child_of=root_span) as map_span:
+        # start_active_span() will use tracer's scope manager to determine active span
+        # for automatic parentage.  Here "pi_map" span will be a child of "pi_approximation" span.
+        with opentracing.tracer.start_active_span('pi_map') as map_scope:
+            map_span = map_scope.span
             # Set sequential phase level tags for child context
             map_span.set_tag('pi_map.partials', partials)
             map_span.set_tag('pi_map.partial_terms', partial_terms)
             map_span.set_tag('pi_map.batch_size', batch_size)
 
-            queue = Queue()
+            queue = Queue.Queue()
 
             # Log events for annotations in SignalFx
             map_span.log_kv(dict(event='Scheduling requests.'))
@@ -42,16 +44,16 @@ def approximate_pi(partials, partial_terms, batch_size, url):
             with ThreadPoolExecutor(batch_size) as exe:
                 start = 0
                 for _ in range(partials):
-                    # Pass map_span w/ executor submission as opentracing_instrumentation
-                    # utils use threading.local(), so get_current_span() will return None
-                    # when invoked on separate thread.
+                    # Here we manually pass map_span w/ executor submission as default scope manager
+                    # uses threading.local(), so tracer.scope_manager.active() would return None
+                    # when invoked on separate thread.  OpenTracing Spans are thread-safe.
                     exe.submit(request_partial, start, start + partial_terms, queue, url, map_span)
                     start += partial_terms
 
             map_span.log_kv(dict(event='Received all responses.'))
 
         # Simple child span without additional tags or logs.
-        with opentracing.tracer.start_span('pi_reduce', child_of=root_span):
+        with opentracing.tracer.start_active_span('pi_reduce'):
             approx = 0
             for _ in range(partials):
                 approx += queue.get()
@@ -96,7 +98,7 @@ if __name__ == '__main__':
     ap.add_argument('-a', '--access-token', dest='access_token', type=str, default='',
                     help='Your SignalFx access token.')
     ap.add_argument('-i', '--ingest', dest='ingest', type=str, default='https://ingest.signalfx.com/v1/trace',
-                    help='SignalFx ingest url (default https://ingest.signalfx.com/v1/trace)')
+                    help='SignalFx Agent, Gateway, or ingest url (default https://ingest.signalfx.com/v1/trace)')
     ap.add_argument('-p', '--partials', dest='partials', type=int, default=20,
                     help='Number of partial requests to make (default 20).')
     ap.add_argument('-t', '--partial-terms', dest='partial_terms', type=int, default=500000,
@@ -107,22 +109,18 @@ if __name__ == '__main__':
                     help='Port for running PiServer (default 9090)')
     args = ap.parse_args()
 
-    config = Config(
-        config={
-            'sampler': {
-                'type': 'const',  # Report all spans.  Not recommended for production environments
-                'param': 1,
-            },
-            'propagation': 'b3',
-            'jaeger_endpoint': args.ingest,
-            'jaeger_format_params': '',
-            'jaeger_user': 'auth',
-            'jaeger_password': args.access_token,
-            'logging': True,
-        },
-        service_name='PiClient',
-        validate=True,
-    )
+    jaeger_config = {
+        'sampler': {'type': 'const',  # Report all spans for analysis by SignalFx Gateway
+                    'param': 1},
+        'propagation': 'b3',
+        'jaeger_endpoint': args.ingest,
+        'logging': True,
+    }
+    if args.access_token:  # Authorization info not needed for Smart Agent or Gateway
+        jaeger_config['jaeger_user'] = 'auth'
+        jaeger_config['jaeger_password'] = args.access_token
+
+    config = Config(config=jaeger_config, service_name='PiClient', validate=True)
 
     # this call also sets opentracing.tracer
     tracer = config.initialize_tracer()

--- a/jaeger-python/pi_trace/pi_server.py
+++ b/jaeger-python/pi_trace/pi_server.py
@@ -4,7 +4,6 @@ import traceback
 import logging
 import json
 
-from opentracing_instrumentation import span_in_context
 from six.moves import BaseHTTPServer as http_server
 from six.moves import socketserver
 from jaeger_client import Config
@@ -14,7 +13,6 @@ import opentracing
 from propagation import propagated_context
 from leibniz import calculate_partial
 
-
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level='DEBUG')
 
 
@@ -22,6 +20,7 @@ class PiHandler(http_server.BaseHTTPRequestHandler):
     """An instrumented request handler that calculates partial pi approximations
     based on the "term_start" and "term_end" json field values of the POST request body
     """
+
     def do_POST(self):
         # Get previously initialized tracer or a noop tracer if not globally initialized.
         # Noop tracer provides noop tracer and span implementations for all high-level interfaces.
@@ -40,8 +39,9 @@ class PiHandler(http_server.BaseHTTPRequestHandler):
                      tags.HTTP_METHOD: 'POST',
                      tags.PEER_ADDRESS: ':'.join(map(str, self.client_address))}
 
-        # Opentracing spans provide helpful context manager for transparent span scoping
-        with tracer.start_span('post_handler', child_of=span_ctx, tags=span_tags) as span:
+        # Opentracing spans provide helpful context scope manager for transparent span scoping
+        with tracer.start_active_span('post_handler', child_of=span_ctx, tags=span_tags) as scope:
+            span = scope.span  # obtain the span from the active scope
             # Set request-level tags
             span.set_tag('post_handler.headers', json.dumps(headers))
 
@@ -53,12 +53,7 @@ class PiHandler(http_server.BaseHTTPRequestHandler):
 
                 # Log events for annotation creation in SignalFx
                 span.log_kv(dict(event='calculation beginning.'))
-
-                # Provide subsequent, shared thread invocations of
-                # opentracing_instumentation.get_current_span() with this span
-                with span_in_context(span):
-                    partial_sum = calculate_partial(start, end)
-
+                partial_sum = calculate_partial(start, end)
                 span.log_kv(dict(event='calculation finished.'))
             except Exception as e:
                 span.set_tag(tags.ERROR, True)
@@ -67,7 +62,7 @@ class PiHandler(http_server.BaseHTTPRequestHandler):
                              'error.kind': str(type(e)),
                              'error.object': tb})
                 span.set_tag(tags.HTTP_STATUS_CODE, 500)
-                self.write_response('Error occurred while processing request:\n{}' .format(tb), 500)
+                self.write_response('Error occurred while processing request:\n{}'.format(tb), 500)
             else:
                 span.set_tag(tags.HTTP_STATUS_CODE, 200)
                 self.write_response(str(partial_sum), 200)
@@ -94,22 +89,21 @@ if __name__ == '__main__':
     args = ap.parse_args()
 
     # Establish a jaeger-client-python configuration to report spans to SignalFx
-    config = Config(
-        config={
-            'sampler': {
-                'type': 'const',
-                'param': 1,
-            },
-            'propagation': 'b3',  # Interoperable with Zipkin and Jaeger traces
-            'jaeger_endpoint': args.ingest,
-            'jaeger_format_params': '',  # No format query parameters required by SignalFx
-            'jaeger_user': 'auth',  # Required static username for Access Token authentication via Basic Access
-            'jaeger_password': args.access_token,  # Your organization's Access Token
-            'logging': True,  # Report helpful span submission statements and errors to log handler
-        },
-        service_name='PiServer',  # Service name (low cardinality)
-        validate=True,  # Have jaeger_client fail quickly on invalid configuration
-    )
+    jaeger_config = {
+        'sampler': {'type': 'const',  # Report all spans for analysis by SignalFx Gateway
+                    'param': 1},
+        'propagation': 'b3',  # Interoperable with Zipkin and Jaeger traces
+        'jaeger_endpoint': args.ingest,
+        'logging': True,  # Report helpful span submission statements and errors to log handler
+    }
+    if args.access_token:  # Authorization info not needed for Smart Agent or Gateway
+        # Required static username for organization Access Token authentication via Basic Access
+        jaeger_config['jaeger_user'] = 'auth'
+        jaeger_config['jaeger_password'] = args.access_token
+
+    config = Config(config=jaeger_config,
+                    service_name='PiServer',  # Service name (low cardinality)
+                    validate=True)  # Have jaeger_client fail quickly on invalid configuration
 
     # Globally sets opentracer.tracer to use jaeger_client over default noop tracer
     tracer = config.initialize_tracer()
@@ -119,3 +113,5 @@ if __name__ == '__main__':
         server.serve_forever()
     except KeyboardInterrupt:
         pass
+
+    tracer.close()

--- a/jaeger-python/requirements.txt
+++ b/jaeger-python/requirements.txt
@@ -1,5 +1,5 @@
-git+git://github.com/signalfx/jaeger-client-python@http_sender
-opentracing_instrumentation==2.4.1
+git+git://github.com/signalfx/jaeger-client-python@ot_20_http_sender
+opentracing==2.0.0
 requests
 futures
 six


### PR DESCRIPTION
Removes opentracing_instrumentation dependency and uses OT2.0 interface.