### PR TITLE
Allow setting Gateway url in Lambda examples

### DIFF
--- a/aws-lambda/README.md
+++ b/aws-lambda/README.md
@@ -25,7 +25,7 @@ requests to an API Gateway endpoint.
           |      ↑ 
       Trigger  Respond 
           ↓      |        
-    [Your Lambda Function] — Spans via HTTP POST → [SignalFx]
+    [Your Lambda Function] — Spans via HTTP POST → [SignalFx Gateway]
 ```
 
 If you are using asynchronous or non-`RequestResponse` invocation types, the examples can still serve
@@ -37,14 +37,17 @@ will need to be updated to reflect your application's functionality.
 ## Deployment and Configuration
 
 Each example provides a description of generating and configuring a Deployment Package for its respective
-runtime.  All of these examples presume the setting of the `SIGNALFX_ACCESS_TOKEN` environment variable
-to associate your traces with your organization.  If this variable is not set for your Lambda function via the
-AWS Console or CLI, all invocations will generate an internal server error that will be logged to CloudWatch.
+runtime.  All of these examples presume the setting of the `SIGNALFX_INGEST_URL` environment variable to
+forward your traces to your deployed SignalFx Gateway or `SIGNALFX_ACCESS_TOKEN` for direct association
+with your organization.  **Please note that bypassing the SignalFx Gateway is for demonstration purposes
+only, and is not a supported deployment pattern.  The Gateway enables many powerful analytical features for
+μAPM.** If neither the variables are set for your Lambda function via the AWS Console or CLI, all invocations
+will generate an internal server error that will be logged to CloudWatch.
 
 ```
 $ update-function-configuration \
   --function-name <MyTracedFunction> \
-  --environment Variables={SIGNALFX_ACCESS_TOKEN=<MyAccessToken>}
+  --environment Variables={SIGNALFX_INGEST_URL=<MyGateway>}
 ```
 
 

--- a/aws-lambda/jaeger-go/README.md
+++ b/aws-lambda/jaeger-go/README.md
@@ -20,8 +20,8 @@ $ zip my_traced_golang_lambda.zip ./jaeger-go
 
 The resulting `my_traced_golang_lambda.zip` can be uploaded to S3 or in your browser via the AWS Console
 during function creation. Register your handler as `jaeger-go` and don't forget to set the
-`SIGNALFX_ACCESS_TOKEN` environment variable.  You should be able test the application with
-the following test event:
+`SIGNALFX_INGEST_URL` environment variable to point to your Gateway.  You should be able test the application
+with the following test event:
 
 ```
 {

--- a/aws-lambda/jaeger-java/README.md
+++ b/aws-lambda/jaeger-java/README.md
@@ -17,8 +17,8 @@ $ mvn package
 
 The resulting `./target/lambda-java-example.jar` can be uploaded to S3 or in your browser via the AWS Console
 during function creation.  Register your handler as `example.RoulettePlayer::handleRequest` and don't forget
-to set the `SIGNALFX_ACCESS_TOKEN` environment variable.  You should be able verify the application with
-the following test event:
+to set the `SIGNALFX_INGEST_URL` environment variable to point to your Gateway.  You should be able verify the
+application with the following test event:
 
 ```
 {

--- a/aws-lambda/jaeger-nodejs/README.md
+++ b/aws-lambda/jaeger-nodejs/README.md
@@ -17,8 +17,8 @@ $ zip -r my_traced_node_lambda.zip *
 
 The resulting `my_traced_node_lambda.zip` can be uploaded to S3 or in your browser via the AWS Console
 during function creation. Register your handler as `index.requestHandler` and don't forget to set the
-`SIGNALFX_ACCESS_TOKEN` environment variable.  You should be able test the application with
-the following test event:
+`SIGNALFX_INGEST_URL` environment variable to point to your Gateway.  You should be able test the application
+with the following test event:
 
 ```
 {

--- a/aws-lambda/jaeger-python/README.md
+++ b/aws-lambda/jaeger-python/README.md
@@ -24,8 +24,8 @@ $ zip -r my_traced_python_lambda.zip *
 
 The resulting `my_traced_python_lambda.zip` can be uploaded to S3 or in your browser via the AWS Console
 during function creation. Register your handler as `example.request_handler` and don't forget to set the
-`SIGNALFX_ACCESS_TOKEN` environment variable.  You should be able test the application with
-the following test event:
+`SIGNALFX_INGEST_URL` environment variable to point to your Gateway.  You should be able test the application
+with the following test event:
 
 ```
 {


### PR DESCRIPTION
The changes add `SIGNALFX_INGEST_URL` env var support and remove the access token requirement for all AWS Lambda examples.