### PR TITLE
Add setup.cfg to python lambda example

### DIFF
--- a/aws-lambda/jaeger-python/setup.cfg
+++ b/aws-lambda/jaeger-python/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix= 


### PR DESCRIPTION
This should allow pip to install to a target directory