### PR TITLE
Add java custom tag example

### DIFF
--- a/java-customtags/README.md
+++ b/java-customtags/README.md
@@ -1,0 +1,25 @@
+# Java Custom Tag Example
+
+This example assumes an already configured SignalFx SmartGateway and SmartAgent. They can be running on the same machine as the example below however it is recommended to have at least 6GB RAM for this test.
+
+This is an example of how to set custom tags for a span in Java.
+Tags for the span name along with a customer key:value tag are easily set.
+
+## Building
+
+The example EchoServer.java example has comments indicating proper place for settings.
+
+EchoServer.java will run a Jetty Embeded HTTP Server. 
+
+To build and run the server, use the included shell script:
+```
+$ sh run-server.sh
+```
+You can change the name of the demo application by editing ```run-server.sh```
+
+## Generating Traces
+
+To execute many times and generate a large number of traces for testing use:
+```
+$ for n in {1..5000}; do curl http://localhost:5000/echo; done
+```

--- a/java-customtags/README.md
+++ b/java-customtags/README.md
@@ -1,9 +1,9 @@
 # Java Custom Tag Example
 
-This example assumes an already configured SignalFx SmartGateway and SmartAgent. They can be running on the same machine as the example below however it is recommended to have at least 6GB RAM for this test.
-
 This is an example of how to set custom tags for a span in Java.
 Tags for the span name along with a customer key:value tag are easily set.
+
+This example assumes an already configured SignalFx SmartGateway and SmartAgent. They can be running on the same machine as the example below however it is recommended to have at least 6GB RAM for this test.
 
 ## Building
 

--- a/java-customtags/pom.xml
+++ b/java-customtags/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.signalfx.public</groupId>
+  <artifactId>java-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.24.v20191120</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <version>0.31.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.signalfx.public</groupId>
+      <artifactId>signalfx-trace-api</artifactId>
+      <version>0.28.0-sfx6</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/java-customtags/run-server.sh
+++ b/java-customtags/run-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -x
+
+export SIGNALFX_SERVICE_NAME=EchoServer-JavaTagDemo
+
+mvn compile exec:exec \
+  -Dexec.executable="java" \
+  -Dexec.args="-javaagent:/opt/signalfx-tracing.jar -cp %classpath sf.main.EchoDemo 5000"

--- a/java-customtags/src/main/java/sf/main/EchoDemo.java
+++ b/java-customtags/src/main/java/sf/main/EchoDemo.java
@@ -1,0 +1,52 @@
+package sf.main;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+
+import com.signalfx.tracing.api.Trace;
+import com.signalfx.tracing.context.TraceScope;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+
+// The span name is set below as "MyOperation"
+// The custom tag for the span is set below with key:value "MyTag", "CustomTag"		
+
+public class EchoDemo extends AbstractHandler {
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+        HttpServletResponse response) throws IOException, ServletException {
+	try (Scope scope = GlobalTracer.get().buildSpan("MyOperation").startActive(true)) {
+   	    scope.span().setTag("MyTag", "CustomTag");
+       	    response.setContentType("text/plain;charset=utf-8");
+       	    response.setStatus(HttpServletResponse.SC_OK);
+       	    baseRequest.setHandled(true);
+       	    response.getWriter().println("Hello world");
+	    scope.close();
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        Server server = new Server(5000);
+        server.setHandler(new EchoDemo());
+        server.start();
+        server.join();
+    }
+}


### PR DESCRIPTION
I've updated the APM training example with a refreshed pom.xml and created a new version of a Jetty HTTP server with a Java example showing how to set custom tags in Java per request for an example.

The result is this new Java tracing example added by this pull request.