### PR TITLE
Updates for Windows Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For customers who have not instrumented their applications, or have done so in
 an OpenTracing-compatible fashion, we offer several SignalFx Tracing libraries.
 Their detailed documentation is available in their respective source locations:
 
-- [.NET Core on Linux](https://github.com/signalfx/signalfx-dotnet-tracing)
+- [.NET](https://github.com/signalfx/signalfx-dotnet-tracing)
 - [Go](https://github.com/signalfx/signalfx-go-tracing)
 - [Java](https://github.com/signalfx/signalfx-java-tracing)
 - [Node.js](https://github.com/signalfx/signalfx-nodejs-tracing)

--- a/signalfx-tracing/README.md
+++ b/signalfx-tracing/README.md
@@ -8,7 +8,7 @@ environment of choice than general documentation can sometimes be.
 
 ## SignalFx Tracing Supported Languages and Platforms
 
-- [.NET Core on Linux](./signalfx-dotnet-tracing)
+- [.NET](./signalfx-dotnet-tracing)
 - [Go](./signalfx-go-tracing)
 - [Java](./signalfx-java-tracing)
 - [Node.js](./signalfx-nodejs-tracing)

--- a/signalfx-tracing/signalfx-dotnet-tracing/README.md
+++ b/signalfx-tracing/signalfx-dotnet-tracing/README.md
@@ -1,10 +1,10 @@
-# The SignalFx Tracing Library for .NET Core on Linux
+# The SignalFx Tracing Library for .NET
 
 This repository contains an example application that utilizes auto-instrumentation for the
-ASP.NET Core framework and an http and database client. <br/>
+ASP.NET Core and an http and database client. <br/>
 
 For more detailed information about the functionality of the provided tracer and instrumentation configuration,
-please see the [SignalFx Tracing Library for .NET Core on Linux project](https://github.com/signalfx/signalfx-dotnet-tracing/).
+please see the [SignalFx Tracing Library for .NET project](https://github.com/signalfx/signalfx-dotnet-tracing/).
 
 ## Libraries and Framework Examples
 - [ASP.NET Core and MongoDb](./aspnetcore-and-mongodb)

--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/README.md
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/README.md
@@ -1,7 +1,7 @@
 # ASP.NET Core and MongoDb Auto-Instrumentation Example
 
 This is an example of automatically producing distributed traces using the
-[SignalFx Tracing Library for .NET Core on Linux](https://github.com/signalfx/signalfx-dotnet-tracing).
+[SignalFx Tracing Library for .NET](https://github.com/signalfx/signalfx-dotnet-tracing).
 Please examine the instrumented [HttpClient](./src/ExampleClient/Program.cs) and [ASP.NET Core application](./src/AspNetCoreExample/Services/ItemService.cs)
 for custom instrumentation patterns using the OpenTracing API. This example is of a simple
 inventory system that is auto-instrumented via [configuration of the CLR Profiler and tracing library](./src/AspNetCoreExample/Dockerfile).


### PR DESCRIPTION
I'm not sure when we want this to go live but here are the changes for releasing .NET for Windows. The examples also work for Windows - they require docker on Windows running Linux but that is what most people have docker on Windows anyway.