### PR TITLE
Update SFx nuget packages to version 0.1.6

### DIFF
--- a/dotnet-manual-instrumentation/Azure.Functions/Azure.Functions.csproj
+++ b/dotnet-manual-instrumentation/Azure.Functions/Azure.Functions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
-    <PackageReference Include="SignalFx.Tracing.OpenTracing" Version="0.1.4" />
+    <PackageReference Include="SignalFx.Tracing.OpenTracing" Version="0.1.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/dotnet-manual-instrumentation/SignalFx.OpenTracing.Manually.Instrumented.App/SignalFx.OpenTracing.Manually.Instrumented.App.csproj
+++ b/dotnet-manual-instrumentation/SignalFx.OpenTracing.Manually.Instrumented.App/SignalFx.OpenTracing.Manually.Instrumented.App.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SignalFx.Tracing.OpenTracing" Version="0.1.4" />
+      <PackageReference Include="SignalFx.Tracing.OpenTracing" Version="0.1.6" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update SFx nuget packages to version 0.1.6 on manual example for .NET.