### PR TITLE
Using OpenTracing Shim from OpenTelemetry

### DIFF
--- a/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/pom.xml
+++ b/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/pom.xml
@@ -26,13 +26,16 @@
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>
       <version>0.32.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.signalfx.public</groupId>
       <artifactId>signalfx-trace-api</artifactId>
       <version>0.36.0-sfx9</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-opentracing-shim</artifactId>
+      <version>0.10.0</version>
     </dependency>
 
     <dependency>

--- a/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/src/main/java/com/signalfx/tracing/examples/javaagent/App.java
+++ b/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/src/main/java/com/signalfx/tracing/examples/javaagent/App.java
@@ -1,7 +1,7 @@
 package com.signalfx.tracing.examples.javaagent;
 
 import com.signalfx.tracing.api.Trace;
-import com.signalfx.tracing.context.TraceScope;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
@@ -53,6 +53,8 @@ public class App {
             System.out.println("Please specify a URL to fetch");
             System.exit(1);
         }
+
+        GlobalTracer.registerIfAbsent(OpenTracingShim.createTracerShim());
 
         String url = argv[0];
 
@@ -115,13 +117,6 @@ public class App {
         // This accesses the span created by the @Trace annotation and adds a tag to it.
         Span activeSpan = GlobalTracer.get().scopeManager().activeSpan();
         activeSpan.setTag("my-tag", "my-value");
-
-        // Set a flag on the current scope to allow automatic propagation across thread boundaries.  If you did not
-        // set this and wanted to continue with the current trace in a new thread, you would need to pass the Span
-        // instance across to the thread in a closure and then reactive it manually with
-        // `GlobalTracer.get().scopeManager().activate(span, finishOnClose)` in the thread method/function.
-        // The current scope contains the span created by the @Trace annotation on this method.
-        ((TraceScope) GlobalTracer.get().scopeManager().activate(activeSpan)).setAsyncPropagation(true);
 
         executor.submit(() -> redisClient.set(url, value));
     }


### PR DESCRIPTION
This PR adapts tracing example to work with Splunk OpenTelemetry Java distribution.

Integration with OpenTracing API is provided by [OpenTelemetry-OpenTracing shim](https://github.com/open-telemetry/opentelemetry-java/tree/master/opentracing-shim).

If application actually uses SignalFx API, such as `com.signalfx.tracing.api.Trace`, then API jar has to be on the application's classpath. It is not provided by otel javaagent. The same story with `opentracing-util`.