### PR TITLE
fix: signalfx-dotnet-tracing deb package URL

### DIFF
--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/AspNetCoreExample/Dockerfile
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/AspNetCoreExample/Dockerfile
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1
 COPY --from=build /build/publish /app
 WORKDIR /app
 
-ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.1.2/signalfx-dotnet-tracing_0.1.2_amd64.deb  /tmp/sdt.deb
+ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.1.8/signalfx-dotnet-tracing_0.1.8_amd64.deb /tmp/sdt.deb
 RUN dpkg -i /tmp/sdt.deb
 
 RUN mkdir /var/log/signalfx

--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/ClientExample/Dockerfile
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/ClientExample/Dockerfile
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1
 COPY --from=build /build/publish /app
 WORKDIR /app
 
-ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest/download/signalfx-dotnet-tracing.deb  /tmp/sdt.deb
+ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.1.2/signalfx-dotnet-tracing_0.1.2_amd64.deb /tmp/sdt.deb
 RUN dpkg -i /tmp/sdt.deb
 
 RUN mkdir /var/log/signalfx

--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/ClientExample/Dockerfile
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/src/ClientExample/Dockerfile
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1
 COPY --from=build /build/publish /app
 WORKDIR /app
 
-ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.1.2/signalfx-dotnet-tracing_0.1.2_amd64.deb /tmp/sdt.deb
+ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.1.8/signalfx-dotnet-tracing_0.1.8_amd64.deb /tmp/sdt.deb
 RUN dpkg -i /tmp/sdt.deb
 
 RUN mkdir /var/log/signalfx


### PR DESCRIPTION
## Why

The URL to deb package in ClientExample was invalid. It was impossible to build the Docker container.

## What

Fix the URL and update the URL for AspNetCoreExample.