### PR TITLE
Remove OpenTracing from dotnet examples

### DIFF
--- a/opentelemetry-tracing/opentelemetry-dotnet/automatic/aspnetcore-and-mongodb/README.md
+++ b/opentelemetry-tracing/opentelemetry-dotnet/automatic/aspnetcore-and-mongodb/README.md
@@ -18,7 +18,7 @@ To build and run the example services, clone this repository, move to this folde
 
 ```sh
 docker build ../../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/ -t aspnetcore-and-mongodb-server-app
-docker build ../../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ -t aspnetcore-and-mongdb-client-app
+docker build ../../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ -t aspnetcore-and-mongodb-client-app
 docker-compose build
 SPLUNK_ACCESS_TOKEN=<access_token> SPLUNK_REALM=<realm> docker-compose up
 ```

--- a/opentelemetry-tracing/opentelemetry-dotnet/automatic/aspnetcore-and-mongodb/docker-compose.yml
+++ b/opentelemetry-tracing/opentelemetry-dotnet/automatic/aspnetcore-and-mongodb/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: InstrumentContainer
       args:
-        - SOURCE_CONTAINER=aspnetcore-and-mongdb-server-app
+        - SOURCE_CONTAINER=aspnetcore-and-mongodb-server-app
     ports:
      - "5000:5000"
     environment:
@@ -23,7 +23,7 @@ services:
     build:
       context: InstrumentContainer
       args:
-        - SOURCE_CONTAINER=aspnetcore-and-mongdb-client-app
+        - SOURCE_CONTAINER=aspnetcore-and-mongodb-client-app
     environment:
       - OTEL_SERVICE_NAME=example-client
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=otel-dotnet-auto-tracing-examples,service.version=1.0.0

--- a/opentelemetry-tracing/opentelemetry-dotnet/manual/aspnetcore-and-mongodb/src/ClientExample/ClientExample.csproj
+++ b/opentelemetry-tracing/opentelemetry-dotnet/manual/aspnetcore-and-mongodb/src/ClientExample/ClientExample.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="OpenTelemetry" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 

--- a/opentelemetry-tracing/opentelemetry-dotnet/manual/aspnetcore-and-mongodb/src/ClientExample/Program.cs
+++ b/opentelemetry-tracing/opentelemetry-dotnet/manual/aspnetcore-and-mongodb/src/ClientExample/Program.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
-using OpenTracing;
-using OpenTracing.Util;
 
 namespace ClientExample 
 {

--- a/shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/AspNetCoreExample.csproj
+++ b/shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/AspNetCoreExample.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.9.0" />
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 
 </Project>

--- a/shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/Services/ItemService.cs
+++ b/shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/Services/ItemService.cs
@@ -2,80 +2,48 @@
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Linq;
-using OpenTracing;
-using OpenTracing.Util;
-
 namespace AspNetCoreExample.Services
 {
     public class ItemService
     {
         private readonly IMongoCollection<Item> _Items;
 
-        private static ITracer tracer = GlobalTracer.Instance;
-
         public ItemService(ItemsDatabaseSettings settings)
         {
-            using (var scope = tracer.BuildSpan("establish.ItemService").IgnoreActiveSpan().StartActive(finishSpanOnDispose: true))
-            {
-                var client = new MongoClient(settings.ConnectionString);
-                var database = client.GetDatabase(settings.DatabaseName);
-                _Items = database.GetCollection<Item>(settings.ItemsCollectionName);
-            }
+            var client = new MongoClient(settings.ConnectionString);
+            var database = client.GetDatabase(settings.DatabaseName);
+            _Items = database.GetCollection<Item>(settings.ItemsCollectionName);
         }
 
         public List<Item> Get()
         {
-            using (var scope = tracer.BuildSpan("GetItems").StartActive(finishSpanOnDispose: true))
-            {
-                return _Items.Find(Item => true).ToList();
-            }
+            return _Items.Find(Item => true).ToList();
         }
 
         public Item Get(string id)
         {
-            using (var scope = tracer.BuildSpan("GetItem").StartActive(finishSpanOnDispose: true))
-            {
-                scope.Span.SetTag("item.id", id);
-                return _Items.Find<Item>(Item => Item.Id == id).FirstOrDefault();
-            }
+            return _Items.Find<Item>(Item => Item.Id == id).FirstOrDefault();
         }
 
         public Item Create(Item Item)
         {
-            using (var scope = tracer.BuildSpan("CreateItem").StartActive(finishSpanOnDispose: true))
-            {
-                _Items.InsertOne(Item);
-                scope.Span.SetTag("item.id", Item.Id);
-                return Item;
-            }
+            _Items.InsertOne(Item);
+            return Item;
         }
 
         public void Update(string id, Item ItemIn)
         {
-            using (var scope = tracer.BuildSpan("UpdateItem").StartActive(finishSpanOnDispose: true))
-            {
-                scope.Span.SetTag("item.id", id);
-                _Items.ReplaceOne(Item => Item.Id == id, ItemIn);
-            }
-
+            _Items.ReplaceOne(Item => Item.Id == id, ItemIn);
         }
 
         public void Remove(Item ItemIn)
         {
-            using (var scope = tracer.BuildSpan("RemoveItem").StartActive(finishSpanOnDispose: true))
-            {
-                scope.Span.SetTag("item.id", ItemIn.Id);
-                _Items.DeleteOne(Item => Item.Id == ItemIn.Id);
-            }
+            _Items.DeleteOne(Item => Item.Id == ItemIn.Id);
         }
 
         public void Remove(string id)
         {
-            using (var scope = tracer.BuildSpan("RemoveItem").StartActive(finishSpanOnDispose: true))
-            {
-                scope.Span.SetTag("item.id", id);
-                _Items.DeleteOne(Item => Item.Id == id);
-            }
+            _Items.DeleteOne(Item => Item.Id == id);
         }
     }
 }

--- a/shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ClientExample.csproj
+++ b/shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ClientExample.csproj
@@ -11,7 +11,6 @@
     <!-- the auto instrumentation version is updated.                                                   -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 
 </Project>

--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/README.md
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/README.md
@@ -18,7 +18,7 @@ To build and run the example services, clone this repository, move to this folde
 
 ```sh
 docker build ../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/AspNetCoreExample/ -t aspnetcore-and-mongodb-server-app
-docker build ../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ -t aspnetcore-and-mongdb-client-app
+docker build ../../../shared/applications/dotnet/aspnetcore-and-mongodb/src/ClientExample/ -t aspnetcore-and-mongodb-client-app
 docker-compose build
 SPLUNK_ACCESS_TOKEN=<access_token> SPLUNK_REALM=<realm> docker-compose up
 ```

--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/docker-compose.yml
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: InstrumentContainer
       args:
-        - SOURCE_CONTAINER=aspnetcore-and-mongdb-server-app
+        - SOURCE_CONTAINER=aspnetcore-and-mongodb-server-app
     ports:
      - "5000:5000"
     environment:
@@ -22,7 +22,7 @@ services:
     build:
       context: InstrumentContainer
       args:
-        - SOURCE_CONTAINER=aspnetcore-and-mongdb-client-app
+        - SOURCE_CONTAINER=aspnetcore-and-mongodb-client-app
     environment:
       - SIGNALFX_SERVICE_NAME=example-client
       - SIGNALFX_ENDPOINT_URL=http://splunk-otel-collector:9411/api/v2/spans

--- a/signalfx-tracing/signalfx-dotnet-tracing/cloudfoundry-buildpack/CloudFoundryBuildpackExample.csproj
+++ b/signalfx-tracing/signalfx-dotnet-tracing/cloudfoundry-buildpack/CloudFoundryBuildpackExample.csproj
@@ -5,8 +5,4 @@
     <RootNamespace>CloudFoundryBuildpackExample</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Remove OpenTracing from dotnet examples and opportunistically fix a typo on the name of some images.

For reference:

- OTel manual:
  - https://app.signalfx.com/#/apm/traces/75999bd3436f4fc71e19608fc569496b
  - https://app.signalfx.com/#/apm/traces/3ebc2f462ef0d64795bc628af29baec5
- OTel auto:
  - https://app.signalfx.com/#/apm/traces/16df501a38908ec20cf204b4b7432a77
  - https://app.signalfx.com/#/apm/traces/718cbdda0832f0ea69629792de959ba5
- SFx:
  - https://app.signalfx.com/#/apm/traces/3763d038e10ba38d6fe0a6f2081ef9de
  - https://app.signalfx.com/#/apm/traces/4efd7cf00124c2895711f647f4f3ab95
