### PR TITLE
Add GDI owners for dotnet related examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Locations owned by GDI .NET Team
+/opentelemetry-tracing/opentelemetry-dotnet/ @signalfx/gdi-dotnet-approvers
+/shared/applications/dotnet/                 @signalfx/gdi-dotnet-approvers
+/signalfx-tracing/signalfx-dotnet-tracing/   @signalfx/gdi-dotnet-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Locations owned by GDI .NET Team
+# Locations owned by the GDI .NET Team
 /opentelemetry-tracing/opentelemetry-dotnet/ @signalfx/gdi-dotnet-approvers
 /shared/applications/dotnet/                 @signalfx/gdi-dotnet-approvers
 /signalfx-tracing/signalfx-dotnet-tracing/   @signalfx/gdi-dotnet-approvers


### PR DESCRIPTION
Adding CODEOWNERS file to automate notification of PRs related to dotnet.

I still have to get write access for the team @signalfx/gdi-dotnet-approvers added to the repo.