### PR TITLE
Bump sfx-dotnet-tracing to 1.1.0

### DIFF
--- a/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/InstrumentContainer/Dockerfile
+++ b/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/InstrumentContainer/Dockerfile
@@ -2,7 +2,7 @@ ARG SOURCE_CONTAINER
 FROM ${SOURCE_CONTAINER}
 
 # Add the SFx.NET Instrumentation
-ARG TRACER_VERSION=1.0.1
+ARG TRACER_VERSION=1.1.0
 ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb ./
 
 RUN mkdir -p /var/log/signalfx


### PR DESCRIPTION
Update dockerfile to use the most recently released version of signalfx-dotnet-tracing.