### PR TITLE
OpenTelemetry PHP Symfony auto-instrumentation example

### DIFF
--- a/opentelemetry-tracing/opentelemetry-php/README.md
+++ b/opentelemetry-tracing/opentelemetry-php/README.md
@@ -1,0 +1,8 @@
+# OpenTelemetry PHP examples
+
+This folder contains sample applications that are instrumented using
+[OpenTelemetry PHP](https://github.com/open-telemetry/opentelemetry-php) SDK and its auto-instrumentation modules.
+
+## Libraries and Framework Examples
+
+- [Symfony auto-instrumentation](./symfony-auto/README.md)

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/README.md
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/README.md
@@ -1,0 +1,100 @@
+# PHP Symfony auto-instrumentation example
+
+This example demonstrates using OpenTelemetry PHP auto-instrumentation to collect logs and traces from a Symfony demo application. While traces and logs are automatically collected in this example, it includes an example of manually sending metrics.
+
+## Running the example
+
+### Data sent to Splunk APM
+
+To run the example and send its data to Splunk APM, run the following command in `compose-splunk` directory:
+
+```sh
+SPLUNK_ACCESS_TOKEN=<access_token> SPLUNK_REALM=<realm> docker-compose up
+```
+
+The value for `SPLUNK_ACCESS_TOKEN` can be found
+[here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
+Reference: [docs](https://docs.splunk.com/Observability/admin/authentication-tokens/api-access-tokens.html#admin-api-access-tokens).
+
+The value for `SPLUNK_REALM` can be found
+[here](https://app.signalfx.com/o11y/#/myprofile).
+Reference: [docs](https://docs.splunk.com/Observability/admin/allow-services.html).
+
+### Data logged to console
+
+To run the example and see the collected traces, logs and metrics in console as logged by the collector, run the following command in `compose-log` directory:
+
+```sh
+docker-compose up
+```
+
+### Generating traces and logs
+
+Traces and logs are auto-instrumented, and the Docker Compose configuration exposes the demo application on host port 8080, therefore to generate traces and logs, simply navigate to http://localhost:8080/en/blog/.
+
+### Generating metrics
+
+The [custom controller](./image-php/files/DemoController.php) included in this example adds controller endpoints that create metrics manually by directly using the OpenTelemetry PHP SDK.
+
+Navigate to http://localhost:8080/en/demo/metric-count to increment a sample counter metric, or http://localhost:8080/en/demo/metric-gauge?value=33 to set the value of a gauge metric to a specified value.
+
+## Integration with an existing application
+
+To reproduce the behavior on this demo on an existing Symfony application, the following steps need to be taken:
+- `protobuf` and `opentelemetry` PHP extensions need to be installed
+- OpenTelemetry SDK, exporter, and Symfony and PSR-3 auto-instrumentation dependencies need to be added to `composer.json`
+- OpenTelemetry SDK needs to be configured to be autoloaded, and exporting needs to be configured
+
+### Installing extensions
+
+Installing the required extensions can be done through `pecl` if available:
+```sh
+pecl config-set preferred_state beta
+pecl install protobuf
+pecl install opentelemetry
+```
+
+And these extensions also need to be enabled via an `.ini` file;
+```
+extension=protobuf.so
+extension=opentelemetry.so
+```
+
+### Adding dependencies
+
+Dependencies required for instrumentation (only include PSR-3 if log exporting is needed):
+
+```
+"open-telemetry/sdk": "^1.0",
+"open-telemetry/opentelemetry-auto-symfony": "1.0.0beta22",
+"open-telemetry/opentelemetry-auto-psr3": "^0.0.6",
+```
+
+Dependencies required for OTLP export using `http/protobuf` protocol:
+
+```
+"open-telemetry/exporter-otlp": "^1.0",
+"php-http/guzzle7-adapter": "^1.0",
+```
+
+### Configuration
+
+Configuration is done via environment variables. The best method to set these depends on how the PHP application is launched.
+
+Environment variables to enable SDK autoloading:
+```
+OTEL_PHP_AUTOLOAD_ENABLED=true
+```
+
+Environment variables to export all signals via OTLP:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector-host>:4318
+OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
+OTEL_LOGS_EXPORTER=otlp
+```
+
+Environment variables to enable collecting PSR-3 logs:
+```
+OTEL_PHP_PSR3_MODE=export
+```

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-log/collector-config.yaml
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-log/collector-config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-log/docker-compose.yml
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-log/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+services:
+  php:
+    image: splunk-otel-php-symfony/php
+    build:
+      context: ../image-php
+    ports:
+     - "8080:80"
+    environment:
+      - OTEL_SERVICE_NAME=php-symfony
+      - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=splunk-otel-php-tracing-examples,service.version=1.0.0
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://splunk-otel-collector:4318
+    depends_on:
+      - splunk-otel-collector
+  splunk-otel-collector:
+    image: quay.io/signalfx/splunk-otel-collector:0.92.0
+    command: --config=/collector-config.yaml
+    volumes:
+      - ./collector-config.yaml:/collector-config.yaml
+    expose:
+      - "4318"

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-splunk/docker-compose.yml
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/compose-splunk/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+services:
+  php:
+    image: splunk-otel-php-symfony/php
+    build:
+      context: ../image-php
+    ports:
+     - "8080:80"
+    environment:
+      - OTEL_SERVICE_NAME=php-symfony
+      - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=splunk-otel-php-tracing-examples,service.version=1.0.0
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://splunk-otel-collector:4318
+    depends_on:
+      - splunk-otel-collector
+  splunk-otel-collector:
+    image: quay.io/signalfx/splunk-otel-collector:0.92.0
+    environment:
+      # Provide the following values via command line or fill them in here
+      - SPLUNK_ACCESS_TOKEN
+      - SPLUNK_REALM
+    expose:
+      - "4318"

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/Dockerfile
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-apache
+
+COPY files /files
+RUN chmod +x /files/*.sh
+
+RUN /files/setup-php.sh
+RUN /files/setup-application.sh
+
+ENTRYPOINT ["apache2-foreground"]

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/DemoController.php
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/DemoController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Controller;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/demo')]
+final class DemoController extends AbstractController
+{
+    private CounterInterface $demoCounter;
+    private ObservableGaugeInterface $demoGauge;
+    private int $gaugeValue = 10;
+
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {
+        $meter = Globals::meterProvider()->getMeter('demo-meter');
+        $this->demoCounter = $meter->createCounter('demo-counter');
+        $this->demoGauge = $meter->createObservableGauge('demo-gauge');
+        $this->demoGauge->observe(function (ObserverInterface $observer): void {
+            $observer->observe($this->gaugeValue);
+        });
+    }
+
+    #[Route('/', name: 'demo_index', methods: ['GET'])]
+    public function index(): Response
+    {
+        $this->logger->info('This is a sample log message.');
+
+        return new Response(
+            "<html><body>Logged a sample message</body></html>"
+        );
+    }
+
+    #[Route('/metric-count', name: 'demo_metric_count', methods: ['GET'])]
+    public function metricCount(): Response
+    {
+        $this->demoCounter->add(1, ['demo-attribute' => 'demo-value']);
+        
+        return new Response(
+            "<html><body>Incremented: demo-counter</body></html>"
+        );
+    }
+
+    #[Route('/metric-gauge', name: 'demo_metric_gauge', methods: ['GET'])]
+    public function metricGauge(Request $request): Response
+    {
+        $value = $message = $request->query->has('value') ? intval($request->query->get('value')) : '50';
+        $this->gaugeValue = $value;
+        
+        return new Response(
+            "<html><body>Set: demo-gauge to $value</body></html>"
+        );
+    }
+}

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/extension.ini
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/extension.ini
@@ -1,0 +1,3 @@
+[opentelemetry]
+extension=opentelemetry.so
+extension=protobuf.so

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/setup-application.sh
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/setup-application.sh
@@ -1,0 +1,12 @@
+mkdir -p /var/www/html
+cd /var/www/html
+composer create-project symfony/symfony-demo example 2.5.0
+cd example
+composer update
+composer require -n "open-telemetry/sdk:^1.0"
+composer require -n "open-telemetry/exporter-otlp:^1.0.3"
+composer require -n "php-http/guzzle7-adapter": "^1.0"
+composer require -n "open-telemetry/opentelemetry-auto-symfony:1.0.0beta22"
+composer require -n "open-telemetry/opentelemetry-auto-psr3:^0.0.6"
+cp /files/DemoController.php /var/www/html/example/src/Controller/
+chmod -R 0777 /var/www/html/example/var/log

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/setup-php.sh
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/setup-php.sh
@@ -1,0 +1,13 @@
+apt-get update
+apt-get install -y nano git gcc make autoconf zlib1g-dev libpng-dev unzip libicu-dev gdb
+pecl config-set preferred_state beta
+pecl install opentelemetry
+pecl install protobuf-3.25.1
+a2enmod rewrite
+cp /files/extension.ini /usr/local/etc/php/conf.d/otel.ini
+cp /files/vhost.conf /etc/apache2/sites-available/000-default.conf
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+mv composer.phar /usr/local/bin/composer

--- a/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/vhost.conf
+++ b/opentelemetry-tracing/opentelemetry-php/symfony-auto/image-php/files/vhost.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/example/public/
+
+    <Directory /var/www/html/example/public/>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    SetEnv OTEL_PHP_AUTOLOAD_ENABLED true
+    SetEnv OTEL_PHP_PSR3_MODE export
+    SetEnv OTEL_TRACES_EXPORTER otlp
+    SetEnv OTEL_METRICS_EXPORTER otlp
+    SetEnv OTEL_LOGS_EXPORTER otlp
+</VirtualHost>


### PR DESCRIPTION
Adds an example of a Symfony demo application auto-instrumented with OpenTelemetry PHP auto-instrumentation. As Splunk distribution of OpenTelemetry PHP does not exist yet, there is nothing Splunk-specific about the instrumentation configuration itself. However, the instrumented application exports the signals to Splunk Collector included in the Docker compose setup in this example.