### PR TITLE
Upgrade vulnerable sample dependencies

### DIFF
--- a/opentelemetry-tracing/cloudfoundry-buildpack-java/pom.xml
+++ b/opentelemetry-tracing/cloudfoundry-buildpack-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>3.3.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -16,7 +16,9 @@
     <description>CloudFoundry buildpack demo</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
+        <jackson-bom.version>2.22.0</jackson-bom.version>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencies>
@@ -31,6 +33,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/opentelemetry-tracing/opentelemetry-lambda/python/requirements.txt
+++ b/opentelemetry-tracing/opentelemetry-lambda/python/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.42.0
+fastapi>=0.109.1
 mangum>=0.7.0
 pymongo==4.6.3
 dnspython==2.6.1

--- a/opentelemetry-tracing/opentelemetry-python-tracing/celery/requirements.txt
+++ b/opentelemetry-tracing/opentelemetry-python-tracing/celery/requirements.txt
@@ -1,14 +1,14 @@
 amqp==5.0.6
 billiard==3.6.4.0
 celery==5.2.2
-click==8.0.3
+click==8.3.3
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
-kombu==5.2.1
+kombu==5.2.2
 prompt-toolkit==3.0.22
 pytz==2021.3
-redis==4.5.4
+redis==6.2.0
 six==1.16.0
 vine==5.0.0
 wcwidth==0.2.5

--- a/opentelemetry-tracing/opentelemetry-python-tracing/flask-and-gunicorn/requirements.txt
+++ b/opentelemetry-tracing/opentelemetry-python-tracing/flask-and-gunicorn/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.3.1
-click==8.1.8
+click==8.3.3
 Flask==3.1.3
 gunicorn==22.0.0
 itsdangerous==2.2.0

--- a/opentelemetry-tracing/opentelemetry-python-tracing/flask-and-uwsgi/requirements.txt
+++ b/opentelemetry-tracing/opentelemetry-python-tracing/flask-and-uwsgi/requirements.txt
@@ -1,4 +1,4 @@
-click==8.1.8
+click==8.3.3
 Flask==3.1.3
 googleapis-common-protos==1.75.0
 grpcio==1.75.1

--- a/profiling/workshop/build.gradle.kts
+++ b/profiling/workshop/build.gradle.kts
@@ -14,10 +14,18 @@ tasks.withType<Jar> {
 }
 
 dependencies {
-    implementation("com.sparkjava:spark-core:2.9.3")
+    implementation("com.sparkjava:spark-core:2.9.4")
     implementation("org.slf4j:slf4j-api:1.7.32")
     implementation("org.slf4j:slf4j-simple:1.7.32")
-    implementation("io.opentelemetry:opentelemetry-api:1.0.0")
-    implementation("io.opentelemetry:opentelemetry-extension-annotations:1.0.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.62.0")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.29.0")
 
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.eclipse.jetty" || requested.group == "org.eclipse.jetty.websocket") {
+            useVersion("9.4.57.v20241219")
+        }
+    }
 }

--- a/profiling/workshop/src/main/java/com/splunk/profiling/workshop/DoorGame.java
+++ b/profiling/workshop/src/main/java/com/splunk/profiling/workshop/DoorGame.java
@@ -1,7 +1,7 @@
 package com.splunk.profiling.workshop;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 import java.util.Map;
 import java.util.Random;


### PR DESCRIPTION
## Lazy

Completely driven by codex.

This repo should get archived soon. Until we can navigate our way into that, let's at least try and quiet the scanners a bit by doing the most lazy and minimal dependency upgrades.

## Summary
- upgrade the CloudFoundry Spring Boot sample to Boot 3.3.13, Java 17, OkHttp 4.12.0, Jackson 2.22.0, and Tomcat 10.1.55
- upgrade the profiling workshop Spark/Jetty/OpenTelemetry dependencies and move @WithSpan to the current instrumentation annotations artifact
- upgrade Python requirements for click, redis, fastapi, and fix the existing celery/kombu resolver conflict

## Verification
- ./mvnw -Dmaven.repo.local=/private/tmp/tracing-examples-m2 test
- ./mvnw -Dmaven.repo.local=/private/tmp/tracing-examples-m2 dependency:tree -Dscope=runtime -Dincludes=org.springframework:spring-webmvc,org.yaml:snakeyaml,ch.qos.logback:logback-classic,com.fasterxml.jackson.core:jackson-databind,org.apache.tomcat.embed:tomcat-embed-core,com.squareup.okio:okio,com.squareup.okhttp3:okhttp
- env GRADLE_USER_HOME=/private/tmp/tracing-examples-gradle ./gradlew build
- env GRADLE_USER_HOME=/private/tmp/tracing-examples-gradle ./gradlew dependencies --configuration runtimeClasspath
- env GRADLE_USER_HOME=/private/tmp/tracing-examples-gradle ./gradlew shadowJar
- pip install --dry-run --ignore-installed for the four edited Python requirements files in /private/tmp/tracing-examples-venv
- smoke: Spring sample returned HTTP 200 from /get/example
- smoke: profiling workshop fat jar returned HTTP 200 from /new-game